### PR TITLE
Implement task application service and test cases

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,9 @@ dependencies {
     // Use JUnit Jupiter API for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
 
+    // Use HTTP client for testing.
+    testImplementation 'org.apache.httpcomponents:httpclient:4.3.5'
+
     // Use JUnit Jupiter Engine for testing.
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 

--- a/app/src/main/java/com/codesoom/assignment/App.java
+++ b/app/src/main/java/com/codesoom/assignment/App.java
@@ -1,10 +1,20 @@
 package com.codesoom.assignment;
 
+import com.codesoom.assignment.web.WebServer;
+
+import java.io.IOException;
+
 public class App {
     public String getGreeting() {
         return "Hello World!";
     }
 
     public static void main(String[] args) {
+        try {
+            WebServer server = new WebServer(8000);
+            server.start();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/application/JsonTask.java
+++ b/app/src/main/java/com/codesoom/assignment/application/JsonTask.java
@@ -4,10 +4,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class JsonTask {
+    public Long id;
     public String title;
 
     @JsonCreator
-    public JsonTask(@JsonProperty("title") String title) {
+    public JsonTask(
+            @JsonProperty("id") Long id,
+            @JsonProperty("title") String title
+    ) {
+        this.id = id;
         this.title = title;
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/application/JsonTask.java
+++ b/app/src/main/java/com/codesoom/assignment/application/JsonTask.java
@@ -1,0 +1,13 @@
+package com.codesoom.assignment.application;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class JsonTask {
+    public String title;
+
+    @JsonCreator
+    public JsonTask(@JsonProperty("title") String title) {
+        this.title = title;
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
@@ -31,14 +31,31 @@ public class TaskApplicationService {
     }
 
     public Optional<Object> updateTaskTitle(Long taskId, String newTitle) {
-        return findTask(taskId).map(
-            it -> it.updateTaskTitle(newTitle)
-        ).map(
-            it -> taskMap.put(taskId, it)
+        Optional<Task> targetTask = findTask(taskId).map(
+                it -> it.updateTaskTitle(newTitle)
         );
+        return putTaskToMap(targetTask);
+    }
+
+    private Optional<Object> putTaskToMap(Optional<Task> task) {
+        if (task.isEmpty()) {
+            return Optional.empty();
+        }
+        Task targetTask = task.get();
+        taskMap.put(targetTask.getId(), targetTask);
+        return Optional.of(new Object());
     }
 
     public Optional<Object> deleteTask(Long taskId) {
-        return findTask(taskId).map(it -> taskMap.remove(it.getId()));
+        return deleteTask(findTask(taskId));
+    }
+
+    private Optional<Object> deleteTask(Optional<Task> task) {
+        if (task.isEmpty()) {
+            return Optional.empty();
+        }
+        Task targetTask = task.get();
+        taskMap.remove(targetTask.getId());
+        return Optional.of(new Object());
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
@@ -37,7 +37,8 @@ public class TaskApplicationService {
         taskMap.put(taskId, findTask(taskId).updateTaskTitle(newTitle));
     }
 
-    public void deleteTask(Long taskId) {
-        taskMap.remove(taskId);
+    public void deleteTask(Long taskId) throws NotFoundTask {
+        Task task = findTask(taskId);
+        taskMap.remove(task.getId());
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
@@ -9,8 +9,8 @@ import java.util.List;
 import java.util.Map;
 
 public class TaskApplicationService {
-    Map<Long, Task> taskMap = new HashMap<>();
-    Long lastId = 1L;
+    private final Map<Long, Task> taskMap = new HashMap<>();
+    private Long lastId = 1L;
 
     public List<Task> getAllTasks() {
         return new ArrayList<>(taskMap.values());

--- a/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
@@ -36,4 +36,8 @@ public class TaskApplicationService {
     public void updateTaskTitle(Long taskId, String newTitle) throws NotFoundTask {
         taskMap.put(taskId, findTask(taskId).updateTaskTitle(newTitle));
     }
+
+    public void deleteTask(Long taskId) {
+        taskMap.remove(taskId);
+    }
 }

--- a/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
@@ -1,0 +1,39 @@
+package com.codesoom.assignment.application;
+
+import com.codesoom.assignment.domain.NotFoundTask;
+import com.codesoom.assignment.domain.Task;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TaskApplicationService {
+    Map<Long, Task> taskMap = new HashMap<>();
+
+    public List<Task> getAllTasks() {
+        return new ArrayList<>(taskMap.values());
+    }
+
+    public Long createTask(String title) {
+        Long id = getNextId();
+        Task newTask = new Task(id, title);
+        taskMap.put(id, newTask);
+        return id;
+    }
+
+    public Task findTask(Long taskId) throws NotFoundTask {
+        if (taskMap.containsKey(taskId)) {
+            return taskMap.get(taskId);
+        }
+        throw new NotFoundTask();
+    }
+
+    private Long getNextId() {
+        return (long) taskMap.size();
+    }
+
+    public void updateTaskTitle(Long taskId, String newTitle) throws NotFoundTask {
+        taskMap.put(taskId, findTask(taskId).updateTaskTitle(newTitle));
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
@@ -23,10 +23,10 @@ public class TaskApplicationService {
     }
 
     public Task findTask(Long taskId) throws NotFoundTask {
-        if (taskMap.containsKey(taskId)) {
-            return taskMap.get(taskId);
+        if (!taskMap.containsKey(taskId)) {
+            throw new NotFoundTask();
         }
-        throw new NotFoundTask();
+        return taskMap.get(taskId);
     }
 
     private Long getNextId() {

--- a/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
@@ -1,12 +1,8 @@
 package com.codesoom.assignment.application;
 
-import com.codesoom.assignment.domain.NotFoundTask;
 import com.codesoom.assignment.domain.Task;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class TaskApplicationService {
     private final Map<Long, Task> taskMap = new HashMap<>();
@@ -23,23 +19,26 @@ public class TaskApplicationService {
         return id;
     }
 
-    public Task findTask(Long taskId) throws NotFoundTask {
+    public Optional<Task> findTask(Long taskId) {
         if (!taskMap.containsKey(taskId)) {
-            throw new NotFoundTask();
+            return Optional.empty();
         }
-        return taskMap.get(taskId);
+        return Optional.ofNullable(taskMap.get(taskId));
     }
 
     private Long getNextId() {
         return lastId++;
     }
 
-    public void updateTaskTitle(Long taskId, String newTitle) throws NotFoundTask {
-        taskMap.put(taskId, findTask(taskId).updateTaskTitle(newTitle));
+    public Optional<Object> updateTaskTitle(Long taskId, String newTitle) {
+        return findTask(taskId).map(
+            it -> it.updateTaskTitle(newTitle)
+        ).map(
+            it -> taskMap.put(taskId, it)
+        );
     }
 
-    public void deleteTask(Long taskId) throws NotFoundTask {
-        Task task = findTask(taskId);
-        taskMap.remove(task.getId());
+    public Optional<Object> deleteTask(Long taskId) {
+        return findTask(taskId).map(it -> taskMap.remove(it.getId()));
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/TaskApplicationService.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 public class TaskApplicationService {
     Map<Long, Task> taskMap = new HashMap<>();
+    Long lastId = 1L;
 
     public List<Task> getAllTasks() {
         return new ArrayList<>(taskMap.values());
@@ -30,7 +31,7 @@ public class TaskApplicationService {
     }
 
     private Long getNextId() {
-        return (long) taskMap.size();
+        return lastId++;
     }
 
     public void updateTaskTitle(Long taskId, String newTitle) throws NotFoundTask {

--- a/app/src/main/java/com/codesoom/assignment/application/TaskJsonTransfer.java
+++ b/app/src/main/java/com/codesoom/assignment/application/TaskJsonTransfer.java
@@ -1,0 +1,11 @@
+package com.codesoom.assignment.application;
+
+import com.codesoom.assignment.domain.Task;
+
+import java.util.List;
+
+public class TaskJsonTransfer {
+    public Task jsonStringToTask(String jsonString) {
+        return new Task(-1L, "Play Game");
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/application/TaskJsonTransfer.java
+++ b/app/src/main/java/com/codesoom/assignment/application/TaskJsonTransfer.java
@@ -5,26 +5,39 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class TaskJsonTransfer {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public Task jsonStringToTask(String jsonString) throws JsonProcessingException {
-        JsonTask task = objectMapper.readValue(jsonString, JsonTask.class);
-        return new Task(-1L, task.title);
+    public Optional<Task> jsonStringToTask(String jsonString) {
+        try {
+            JsonTask task = objectMapper.readValue(jsonString, JsonTask.class);
+            return Optional.of(new Task(-1L, task.title));
+        } catch (JsonProcessingException e) {
+            return Optional.empty();
+        }
     }
 
-    public String taskToJson(Task task) throws JsonProcessingException {
-        JsonTask jsonTask = new JsonTask(task.getId(), task.getTitle());
-        return objectMapper.writeValueAsString(jsonTask);
+    public Optional<String> taskToJson(Task task) {
+        try {
+            JsonTask jsonTask = new JsonTask(task.getId(), task.getTitle());
+            return Optional.ofNullable(objectMapper.writeValueAsString(jsonTask));
+        } catch (JsonProcessingException e) {
+            return Optional.empty();
+        }
     }
 
-    public String taskListToJson(List<Task> tasks) throws JsonProcessingException {
-        List<JsonTask> jsonTaskList = tasks
-            .stream()
-            .map(t -> new JsonTask(t.getId(), t.getTitle()))
-            .collect(Collectors.toList());
-        return objectMapper.writeValueAsString(jsonTaskList);
+    public Optional<String> taskListToJson(List<Task> tasks) {
+        try {
+            List<JsonTask> jsonTaskList = tasks
+                .stream()
+                .map(t -> new JsonTask(t.getId(), t.getTitle()))
+                .collect(Collectors.toList());
+            return Optional.ofNullable(objectMapper.writeValueAsString(jsonTaskList));
+        } catch (JsonProcessingException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/application/TaskJsonTransfer.java
+++ b/app/src/main/java/com/codesoom/assignment/application/TaskJsonTransfer.java
@@ -1,11 +1,14 @@
 package com.codesoom.assignment.application;
 
 import com.codesoom.assignment.domain.Task;
-
-import java.util.List;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class TaskJsonTransfer {
-    public Task jsonStringToTask(String jsonString) {
-        return new Task(-1L, "Play Game");
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public Task jsonStringToTask(String jsonString) throws JsonProcessingException {
+        JsonTask task = objectMapper.readValue(jsonString, JsonTask.class);
+        return new Task(-1L, task.title);
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/application/TaskJsonTransfer.java
+++ b/app/src/main/java/com/codesoom/assignment/application/TaskJsonTransfer.java
@@ -11,4 +11,9 @@ public class TaskJsonTransfer {
         JsonTask task = objectMapper.readValue(jsonString, JsonTask.class);
         return new Task(-1L, task.title);
     }
+
+    public String taskToJson(Task task) throws JsonProcessingException {
+        JsonTask jsonTask = new JsonTask(task.getId(), task.getTitle());
+        return objectMapper.writeValueAsString(jsonTask);
+    }
 }

--- a/app/src/main/java/com/codesoom/assignment/application/TaskJsonTransfer.java
+++ b/app/src/main/java/com/codesoom/assignment/application/TaskJsonTransfer.java
@@ -4,6 +4,9 @@ import com.codesoom.assignment.domain.Task;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class TaskJsonTransfer {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -15,5 +18,13 @@ public class TaskJsonTransfer {
     public String taskToJson(Task task) throws JsonProcessingException {
         JsonTask jsonTask = new JsonTask(task.getId(), task.getTitle());
         return objectMapper.writeValueAsString(jsonTask);
+    }
+
+    public String taskListToJson(List<Task> tasks) throws JsonProcessingException {
+        List<JsonTask> jsonTaskList = tasks
+            .stream()
+            .map(t -> new JsonTask(t.getId(), t.getTitle()))
+            .collect(Collectors.toList());
+        return objectMapper.writeValueAsString(jsonTaskList);
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/application/TaskJsonTransfer.java
+++ b/app/src/main/java/com/codesoom/assignment/application/TaskJsonTransfer.java
@@ -33,7 +33,7 @@ public class TaskJsonTransfer {
         try {
             List<JsonTask> jsonTaskList = tasks
                 .stream()
-                .map(t -> new JsonTask(t.getId(), t.getTitle()))
+                .map(it -> new JsonTask(it.getId(), it.getTitle()))
                 .collect(Collectors.toList());
             return Optional.ofNullable(objectMapper.writeValueAsString(jsonTaskList));
         } catch (JsonProcessingException e) {

--- a/app/src/main/java/com/codesoom/assignment/domain/NotFoundTask.java
+++ b/app/src/main/java/com/codesoom/assignment/domain/NotFoundTask.java
@@ -1,0 +1,4 @@
+package com.codesoom.assignment.domain;
+
+public class NotFoundTask extends Throwable {
+}

--- a/app/src/main/java/com/codesoom/assignment/domain/Task.java
+++ b/app/src/main/java/com/codesoom/assignment/domain/Task.java
@@ -23,6 +23,6 @@ public class Task {
 
     @Override
     public String toString() {
-        return "Task:"+String.valueOf(id);
+        return "Task:"+ id;
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/domain/Task.java
+++ b/app/src/main/java/com/codesoom/assignment/domain/Task.java
@@ -1,0 +1,23 @@
+package com.codesoom.assignment.domain;
+
+public class Task {
+    long id;
+    String title;
+
+    public Task(Long id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Task updateTaskTitle(String newTitle) {
+        return new Task(id, newTitle);
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/domain/Task.java
+++ b/app/src/main/java/com/codesoom/assignment/domain/Task.java
@@ -1,8 +1,8 @@
 package com.codesoom.assignment.domain;
 
 public class Task {
-    long id;
-    String title;
+    private long id;
+    private String title;
 
     public Task(Long id, String title) {
         this.id = id;

--- a/app/src/main/java/com/codesoom/assignment/domain/Task.java
+++ b/app/src/main/java/com/codesoom/assignment/domain/Task.java
@@ -20,4 +20,9 @@ public class Task {
     public Task updateTaskTitle(String newTitle) {
         return new Task(id, newTitle);
     }
+
+    @Override
+    public String toString() {
+        return "Task:"+String.valueOf(id);
+    }
 }

--- a/app/src/main/java/com/codesoom/assignment/web/Controller.java
+++ b/app/src/main/java/com/codesoom/assignment/web/Controller.java
@@ -1,0 +1,65 @@
+package com.codesoom.assignment.web;
+
+import com.codesoom.assignment.application.TaskApplicationService;
+import com.codesoom.assignment.application.TaskJsonTransfer;
+import com.codesoom.assignment.domain.Task;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.util.Optional;
+
+public class Controller {
+    TaskApplicationService taskApplicationService;
+    TaskJsonTransfer transfer;
+
+    public Controller(TaskApplicationService taskApplicationService) {
+        this.transfer = new TaskJsonTransfer();
+        this.taskApplicationService = taskApplicationService;
+    }
+
+    HttpResponse getTasks() throws JsonProcessingException {
+        String content = transfer.taskListToJson(taskApplicationService.getAllTasks());
+        return new HttpResponse(200, content);
+    }
+
+    HttpResponse getTasksWithId(Long id) throws JsonProcessingException {
+        Optional<Task> task = taskApplicationService.findTask(id);
+
+        if (task.isEmpty()) {
+            return new HttpResponse(404, "Not Found");
+        }
+        String content = transfer.taskToJson(task.orElseThrow());
+        return new HttpResponse(200, content);
+    }
+
+    HttpResponse postTask(String body) throws JsonProcessingException {
+        Task requestTask = transfer.jsonStringToTask(body);
+
+        Long taskId = taskApplicationService.createTask(requestTask.getTitle());
+        Task task = taskApplicationService.findTask(taskId).orElseThrow();
+
+        String content = transfer.taskToJson(task);
+        return new HttpResponse(201, content);
+    }
+
+    HttpResponse putTask(Long id, String body) throws JsonProcessingException {
+        Task requestTask = transfer.jsonStringToTask(body);
+
+        Optional<Task> result = taskApplicationService.updateTaskTitle(id, requestTask.getTitle())
+                .flatMap(it -> taskApplicationService.findTask(id));
+        if (result.isEmpty()) {
+            return new HttpResponse(404, "Not Found");
+        }
+
+        String content = transfer.taskToJson(result.orElseThrow());
+        return new HttpResponse(200, content);
+    }
+
+    HttpResponse deleteTask(Long id) {
+        Optional<Object> result = taskApplicationService.deleteTask(id);
+
+        if (result.isEmpty()) {
+            return new HttpResponse(404, "Not Found");
+        }
+        return new HttpResponse(204, "Delete");
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/web/Controller.java
+++ b/app/src/main/java/com/codesoom/assignment/web/Controller.java
@@ -16,13 +16,13 @@ public class Controller {
         this.taskApplicationService = taskApplicationService;
     }
 
-    HttpResponse getTasks() throws JsonProcessingException {
+    HttpResponse getTasks(HttpRequest request) throws JsonProcessingException {
         String content = transfer.taskListToJson(taskApplicationService.getAllTasks());
         return new HttpResponse(200, content);
     }
 
-    HttpResponse getTasksWithId(Long id) throws JsonProcessingException {
-        Optional<Task> task = taskApplicationService.findTask(id);
+    HttpResponse getTasksWithId(HttpRequest request) throws JsonProcessingException {
+        Optional<Task> task = taskApplicationService.findTask(request.getTaskId());
 
         if (task.isEmpty()) {
             return new HttpResponse(404, "Not Found");
@@ -31,8 +31,8 @@ public class Controller {
         return new HttpResponse(200, content);
     }
 
-    HttpResponse postTask(String body) throws JsonProcessingException {
-        Task requestTask = transfer.jsonStringToTask(body);
+    HttpResponse postTask(HttpRequest request) throws JsonProcessingException {
+        Task requestTask = transfer.jsonStringToTask(request.requestBody);
 
         Long taskId = taskApplicationService.createTask(requestTask.getTitle());
         Task task = taskApplicationService.findTask(taskId).orElseThrow();
@@ -41,11 +41,12 @@ public class Controller {
         return new HttpResponse(201, content);
     }
 
-    HttpResponse putTask(Long id, String body) throws JsonProcessingException {
-        Task requestTask = transfer.jsonStringToTask(body);
+    HttpResponse putTask(HttpRequest request) throws JsonProcessingException {
+        Long taskId = request.getTaskId();
+        Task requestTask = transfer.jsonStringToTask(request.requestBody);
 
-        Optional<Task> result = taskApplicationService.updateTaskTitle(id, requestTask.getTitle())
-                .flatMap(it -> taskApplicationService.findTask(id));
+        Optional<Task> result = taskApplicationService.updateTaskTitle(taskId, requestTask.getTitle())
+                .flatMap(it -> taskApplicationService.findTask(taskId));
         if (result.isEmpty()) {
             return new HttpResponse(404, "Not Found");
         }
@@ -54,8 +55,8 @@ public class Controller {
         return new HttpResponse(200, content);
     }
 
-    HttpResponse deleteTask(Long id) {
-        Optional<Object> result = taskApplicationService.deleteTask(id);
+    HttpResponse deleteTask(HttpRequest request) {
+        Optional<Object> result = taskApplicationService.deleteTask(request.getTaskId());
 
         if (result.isEmpty()) {
             return new HttpResponse(404, "Not Found");

--- a/app/src/main/java/com/codesoom/assignment/web/ExpectRequestPattern.java
+++ b/app/src/main/java/com/codesoom/assignment/web/ExpectRequestPattern.java
@@ -1,0 +1,18 @@
+package com.codesoom.assignment.web;
+
+public class ExpectRequestPattern {
+    String regex;
+    String method;
+
+    public ExpectRequestPattern(String method, String regex) {
+        this.method = method;
+        this.regex = regex;
+    }
+
+    public boolean isMatched(HttpRequest request) {
+        if (!request.method.equals(this.method)) {
+            return false;
+        }
+        return request.path.matches(regex);
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/web/HttpController.java
+++ b/app/src/main/java/com/codesoom/assignment/web/HttpController.java
@@ -1,0 +1,6 @@
+package com.codesoom.assignment.web;
+
+@FunctionalInterface
+public interface HttpController {
+    public HttpResponse process(HttpRequest request) throws Exception;
+}

--- a/app/src/main/java/com/codesoom/assignment/web/HttpController.java
+++ b/app/src/main/java/com/codesoom/assignment/web/HttpController.java
@@ -1,6 +1,8 @@
 package com.codesoom.assignment.web;
 
+import java.util.Optional;
+
 @FunctionalInterface
 public interface HttpController {
-    public HttpResponse process(HttpRequest request) throws Exception;
+    public Optional<HttpResponse> process(HttpRequest request);
 }

--- a/app/src/main/java/com/codesoom/assignment/web/HttpRequest.java
+++ b/app/src/main/java/com/codesoom/assignment/web/HttpRequest.java
@@ -2,9 +2,11 @@ package com.codesoom.assignment.web;
 
 public class HttpRequest {
     String path;
+    String method;
     String requestBody;
 
-    public HttpRequest(String path, String requestBody) {
+    public HttpRequest(String method, String path, String requestBody) {
+        this.method = method;
         this.path = path;
         this.requestBody = requestBody;
     }

--- a/app/src/main/java/com/codesoom/assignment/web/HttpRequest.java
+++ b/app/src/main/java/com/codesoom/assignment/web/HttpRequest.java
@@ -1,0 +1,16 @@
+package com.codesoom.assignment.web;
+
+public class HttpRequest {
+    String path;
+    String requestBody;
+
+    public HttpRequest(String path, String requestBody) {
+        this.path = path;
+        this.requestBody = requestBody;
+    }
+
+    Long getTaskId() {
+        String resourceId = path.split("/")[2];
+        return (long) Integer.parseInt(resourceId);
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/web/HttpResponse.java
+++ b/app/src/main/java/com/codesoom/assignment/web/HttpResponse.java
@@ -1,0 +1,10 @@
+package com.codesoom.assignment.web;
+
+public class HttpResponse {
+    int statusCode;
+    String content;
+    public HttpResponse(int statusCode, String content){
+        this.content = content;
+        this.statusCode = statusCode;
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/web/Mapping.java
+++ b/app/src/main/java/com/codesoom/assignment/web/Mapping.java
@@ -1,0 +1,11 @@
+package com.codesoom.assignment.web;
+
+public class Mapping {
+    ExpectRequestPattern pattern;
+    HttpController controller;
+
+    public Mapping(ExpectRequestPattern pattern, HttpController controller) {
+        this.controller = controller;
+        this.pattern = pattern;
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -12,13 +12,9 @@ import java.io.OutputStream;
 import java.util.stream.Collectors;
 
 public class WebHandler implements HttpHandler {
-    TaskApplicationService taskApplicationService;
-    TaskJsonTransfer transfer;
     Controller controller;
 
     public WebHandler(TaskApplicationService taskApplicationService) {
-        this.taskApplicationService = taskApplicationService;
-        this.transfer = new TaskJsonTransfer();
         this.controller = new Controller(taskApplicationService);
     }
 

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -25,27 +25,33 @@ public class WebHandler implements HttpHandler {
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
-        if (exchange.getRequestURI().getPath().equals("/tasks")) {
-            String content = transfer.taskListToJson(taskApplicationService.getAllTasks());
-            setJsonToResponseBody(exchange, content, 200);
-        } else if (exchange.getRequestURI().getPath().equals("/task")) {
-            String requestBody = new BufferedReader(
-                    new InputStreamReader(exchange.getRequestBody()))
-                    .lines()
-                    .collect(Collectors.joining(""));
-            Task requestTask = transfer.jsonStringToTask(requestBody);
-
-            Long taskId = taskApplicationService.createTask(requestTask.getTitle());
-            Optional<Task> createdTask = taskApplicationService.findTask(taskId);
-
-            if (createdTask.isEmpty()) {
-                String content = "Not Found";
-                setJsonToResponseBody(exchange, content, 404);
+        String path = exchange.getRequestURI().getPath();
+        String method = exchange.getRequestMethod();
+        if (method.equals("GET")) {
+            if (path.equals("/tasks")) {
+                String content = transfer.taskListToJson(taskApplicationService.getAllTasks());
+                setJsonToResponseBody(exchange, content, 200);
+            } else {
+                exchange.sendResponseHeaders(200, 0);
             }
-            String content = transfer.taskToJson(createdTask.get());
-            setJsonToResponseBody(exchange, content, 201);
-        } else {
-            exchange.sendResponseHeaders(200, 0);
+        } else if (method.equals("POST")) {
+            if (path.equals("/task")) {
+                String requestBody = new BufferedReader(
+                        new InputStreamReader(exchange.getRequestBody()))
+                        .lines()
+                        .collect(Collectors.joining(""));
+                Task requestTask = transfer.jsonStringToTask(requestBody);
+
+                Long taskId = taskApplicationService.createTask(requestTask.getTitle());
+                Optional<Task> createdTask = taskApplicationService.findTask(taskId);
+
+                if (createdTask.isEmpty()) {
+                    String content = "Not Found";
+                    setJsonToResponseBody(exchange, content, 404);
+                }
+                String content = transfer.taskToJson(createdTask.get());
+                setJsonToResponseBody(exchange, content, 201);
+            }
         }
     }
 

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -26,11 +26,13 @@ public class WebHandler implements HttpHandler {
     public void handle(HttpExchange exchange) throws IOException {
         String path = exchange.getRequestURI().getPath();
         String method = exchange.getRequestMethod();
+        System.out.println(path);
+
         if (method.equals("GET")) {
             if (path.equals("/tasks")) {
                 String content = transfer.taskListToJson(taskApplicationService.getAllTasks());
                 setJsonToResponseBody(exchange, content, 200);
-            } else if (path.contains("/task/")) {
+            } else if (path.contains("/tasks/")) {
                 Long taskId = parsePathToTaskId(path);
 
                 Optional<Task> task = taskApplicationService.findTask(taskId);
@@ -39,14 +41,13 @@ public class WebHandler implements HttpHandler {
                     sendNotFoundError(exchange);
                     return;
                 }
-
                 String content = transfer.taskToJson(task.get());
                 setJsonToResponseBody(exchange, content, 200);
             } else {
                 exchange.sendResponseHeaders(200, 0);
             }
         } else if (method.equals("POST")) {
-            if (path.equals("/task")) {
+            if (path.equals("/tasks")) {
                 String requestBody = new BufferedReader(
                         new InputStreamReader(exchange.getRequestBody()))
                         .lines()
@@ -57,7 +58,7 @@ public class WebHandler implements HttpHandler {
                 sendUpdatedTaskResult(exchange, taskId);
             }
         } else if (method.equals("PUT")) {
-            if (path.contains("/task")) {
+            if (path.contains("/tasks")) {
                 Long taskId = parsePathToTaskId(path);
                 String requestBody = new BufferedReader(
                         new InputStreamReader(exchange.getRequestBody()))
@@ -102,7 +103,7 @@ public class WebHandler implements HttpHandler {
     }
 
     private void sendNotFoundError(HttpExchange exchange) throws IOException {
-        String content = "Not Found";
+        String content = "{\"reason\": \"Not Found\"}";
         setJsonToResponseBody(exchange, content, 404);
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -66,6 +66,8 @@ public class WebHandler implements HttpHandler {
                 String content = transfer.taskToJson(createdTask.get());
                 setJsonToResponseBody(exchange, content, 201);
             }
+        } else if (method.equals("PUT")) {
+            exchange.sendResponseHeaders(404, 0);
         }
     }
 

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -8,6 +8,9 @@ import java.io.IOException;
 public class WebHandler implements HttpHandler {
     @Override
     public void handle(HttpExchange exchange) throws IOException {
+        if (exchange.getRequestURI().getPath().equals("/tasks")) {
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+        }
         exchange.sendResponseHeaders(200, 0);
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -74,6 +74,18 @@ public class WebHandler implements HttpHandler {
                 }
                 sendUpdatedTaskResult(exchange, taskId, 200);
             }
+        } else if (method.equals("DELETE")) {
+            if (path.contains("/tasks")) {
+                Long taskId = parsePathToTaskId(path);
+                System.out.println(taskId);
+                Optional<Object> result = taskApplicationService.deleteTask(taskId);
+
+                if (result.isEmpty()) {
+                    sendNotFoundError(exchange);
+                    return;
+                }
+                exchange.sendResponseHeaders(204, 0);
+            }
         } else {
             sendNotFoundError(exchange);
         }

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -31,6 +31,19 @@ public class WebHandler implements HttpHandler {
             if (path.equals("/tasks")) {
                 String content = transfer.taskListToJson(taskApplicationService.getAllTasks());
                 setJsonToResponseBody(exchange, content, 200);
+            } else if (path.contains("/task/")) {
+                String resourceId = path.split("/")[2];
+                Long taskId = (long) Integer.parseInt(resourceId);
+
+                Optional<Task> task = taskApplicationService.findTask(taskId);
+
+                if (task.isEmpty()) {
+                    String content = "Not Found";
+                    setJsonToResponseBody(exchange, content, 404);
+                    return;
+                }
+                String content = transfer.taskToJson(task.get());
+                setJsonToResponseBody(exchange, content, 200);
             } else {
                 exchange.sendResponseHeaders(200, 0);
             }
@@ -48,6 +61,7 @@ public class WebHandler implements HttpHandler {
                 if (createdTask.isEmpty()) {
                     String content = "Not Found";
                     setJsonToResponseBody(exchange, content, 404);
+                    return;
                 }
                 String content = transfer.taskToJson(createdTask.get());
                 setJsonToResponseBody(exchange, content, 201);

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -36,14 +36,8 @@ public class WebHandler implements HttpHandler {
             .filter(
                 it -> it.pattern.isMatched(request)
             ).findFirst()
-            .map(
-                it -> {
-                    try {
-                        return it.controller.process(request);
-                    } catch (Exception e) {
-                        return new HttpResponse(500, "Server error");
-                    }
-                }
+            .flatMap(
+                it -> it.controller.process(request)
             );
 
         writeHttpResponse(exchange, response.orElse(new HttpResponse(404, "Not Found")));
@@ -75,7 +69,7 @@ public class WebHandler implements HttpHandler {
         ));
         mappingList.add(new Mapping(
                 new ExpectRequestPattern("GET", "/"),
-                (request -> new HttpResponse(200, "Welcome to Las's service!"))
+                (request -> Optional.of(new HttpResponse(200, "Welcome to Las's service!")))
         ));
 
         return mappingList;

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -11,6 +11,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class WebHandler implements HttpHandler {
@@ -36,7 +37,7 @@ public class WebHandler implements HttpHandler {
 
             try {
                 Long taskId = taskApplicationService.createTask(requestTask.getTitle());
-                Task createdTask = taskApplicationService.findTask(taskId);
+                Task createdTask = taskApplicationService.findTask(taskId).orElseThrow(NotFoundTask::new);
 
                 String content = transfer.taskToJson(createdTask);
                 setJsonToResponseBody(exchange, content, 201);

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -4,13 +4,23 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
 import java.io.IOException;
+import java.io.OutputStream;
 
 public class WebHandler implements HttpHandler {
     @Override
     public void handle(HttpExchange exchange) throws IOException {
         if (exchange.getRequestURI().getPath().equals("/tasks")) {
+            String content = "[]";
+
             exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, content.getBytes().length);
+
+            OutputStream outputStream = exchange.getResponseBody();
+            outputStream.write(content.getBytes());
+            outputStream.flush();
+            outputStream.close();
+        } else {
+            exchange.sendResponseHeaders(200, 0);
         }
-        exchange.sendResponseHeaders(200, 0);
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -40,7 +40,7 @@ public class WebHandler implements HttpHandler {
                 it -> it.controller.process(request)
             );
 
-        writeHttpResponse(exchange, response.orElse(new HttpResponse(404, "Not Found")));
+        writeHttpResponse(exchange, response.orElse(new HttpResponse(400, "Unknown request!!")));
     }
 
     List<Mapping> prepareMapping() {

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -35,15 +35,15 @@ public class WebHandler implements HttpHandler {
                     .collect(Collectors.joining(""));
             Task requestTask = transfer.jsonStringToTask(requestBody);
 
-            try {
-                Long taskId = taskApplicationService.createTask(requestTask.getTitle());
-                Task createdTask = taskApplicationService.findTask(taskId).orElseThrow(NotFoundTask::new);
+            Long taskId = taskApplicationService.createTask(requestTask.getTitle());
+            Optional<Task> createdTask = taskApplicationService.findTask(taskId);
 
-                String content = transfer.taskToJson(createdTask);
-                setJsonToResponseBody(exchange, content, 201);
-            } catch (NotFoundTask notFoundTask) {
-                notFoundTask.printStackTrace();
+            if (createdTask.isEmpty()) {
+                String content = "Not Found";
+                setJsonToResponseBody(exchange, content, 404);
             }
+            String content = transfer.taskToJson(createdTask.get());
+            setJsonToResponseBody(exchange, content, 201);
         } else {
             exchange.sendResponseHeaders(200, 0);
         }

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -55,7 +55,7 @@ public class WebHandler implements HttpHandler {
                 Task requestTask = transfer.jsonStringToTask(requestBody);
 
                 Long taskId = taskApplicationService.createTask(requestTask.getTitle());
-                sendUpdatedTaskResult(exchange, taskId);
+                sendUpdatedTaskResult(exchange, taskId, 201);
             }
         } else if (method.equals("PUT")) {
             if (path.contains("/tasks")) {
@@ -72,7 +72,7 @@ public class WebHandler implements HttpHandler {
                     sendNotFoundError(exchange);
                     return;
                 }
-                sendUpdatedTaskResult(exchange, taskId);
+                sendUpdatedTaskResult(exchange, taskId, 200);
             }
         }
     }
@@ -84,17 +84,16 @@ public class WebHandler implements HttpHandler {
         OutputStream outputStream = exchange.getResponseBody();
         outputStream.write(content.getBytes());
         outputStream.flush();
-        outputStream.close();
     }
 
-    private void sendUpdatedTaskResult(HttpExchange exchange, Long taskId) throws IOException {
+    private void sendUpdatedTaskResult(HttpExchange exchange, Long taskId, int statusCode) throws IOException {
         Optional<Task> task = taskApplicationService.findTask(taskId);
         if (task.isEmpty()) {
             sendNotFoundError(exchange);
             return;
         }
         String content = transfer.taskToJson(task.get());
-        setJsonToResponseBody(exchange, content, 201);
+        setJsonToResponseBody(exchange, content, statusCode);
     }
 
     private Long parsePathToTaskId(String path){

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -11,16 +11,23 @@ public class WebHandler implements HttpHandler {
     public void handle(HttpExchange exchange) throws IOException {
         if (exchange.getRequestURI().getPath().equals("/tasks")) {
             String content = "[]";
-
-            exchange.getResponseHeaders().set("Content-Type", "application/json");
-            exchange.sendResponseHeaders(200, content.getBytes().length);
-
-            OutputStream outputStream = exchange.getResponseBody();
-            outputStream.write(content.getBytes());
-            outputStream.flush();
-            outputStream.close();
-        } else {
+            setJsonToResponseBody(exchange, content, 200);
+        }
+        else if (exchange.getRequestURI().getPath().equals("/task")){
+            String content = "{\"id\":1,\"title\":\"Play Game\"}";
+            setJsonToResponseBody(exchange, content, 201);
+        }
+        else {
             exchange.sendResponseHeaders(200, 0);
         }
+    }
+    private void setJsonToResponseBody(HttpExchange exchange, String content, int statusCode) throws IOException {
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(statusCode, content.getBytes().length);
+
+        OutputStream outputStream = exchange.getResponseBody();
+        outputStream.write(content.getBytes());
+        outputStream.flush();
+        outputStream.close();
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -24,6 +24,10 @@ public class WebHandler implements HttpHandler {
         String method = exchange.getRequestMethod();
 
         HttpResponse response = null;
+        String requestBody = new BufferedReader(
+                new InputStreamReader(exchange.getRequestBody()))
+                .lines()
+                .collect(Collectors.joining(""));
 
         if (method.equals("GET")) {
             if (path.equals("/tasks")) {
@@ -36,21 +40,11 @@ public class WebHandler implements HttpHandler {
             }
         } else if (method.equals("POST")) {
             if (path.equals("/tasks")) {
-
-                String requestBody = new BufferedReader(
-                        new InputStreamReader(exchange.getRequestBody()))
-                        .lines()
-                        .collect(Collectors.joining(""));
                 response = controller.postTask(requestBody);
             }
         } else if (method.equals("PUT")) {
             if (path.contains("/tasks")) {
                 Long taskId = parsePathToTaskId(path);
-
-                String requestBody = new BufferedReader(
-                        new InputStreamReader(exchange.getRequestBody()))
-                        .lines()
-                        .collect(Collectors.joining(""));
                 response = controller.putTask(taskId, requestBody);
             }
         } else if (method.equals("DELETE")) {

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -1,0 +1,13 @@
+package com.codesoom.assignment.web;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+
+public class WebHandler implements HttpHandler {
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        exchange.sendResponseHeaders(200, 0);
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -2,7 +2,6 @@ package com.codesoom.assignment.web;
 
 import com.codesoom.assignment.application.TaskApplicationService;
 import com.codesoom.assignment.application.TaskJsonTransfer;
-import com.codesoom.assignment.domain.Task;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
@@ -10,104 +9,70 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class WebHandler implements HttpHandler {
     TaskApplicationService taskApplicationService;
     TaskJsonTransfer transfer;
+    Controller controller;
 
     public WebHandler(TaskApplicationService taskApplicationService) {
         this.taskApplicationService = taskApplicationService;
         this.transfer = new TaskJsonTransfer();
+        this.controller = new Controller(taskApplicationService);
     }
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
         String path = exchange.getRequestURI().getPath();
         String method = exchange.getRequestMethod();
-        System.out.println(path);
+
+        HttpResponse response = null;
 
         if (method.equals("GET")) {
             if (path.equals("/tasks")) {
-                String content = transfer.taskListToJson(taskApplicationService.getAllTasks());
-                setJsonToResponseBody(exchange, content, 200);
+                response = controller.getTasks();
             } else if (path.contains("/tasks/")) {
-                Long taskId = parsePathToTaskId(path);
-
-                Optional<Task> task = taskApplicationService.findTask(taskId);
-
-                if (task.isEmpty()) {
-                    sendNotFoundError(exchange);
-                    return;
-                }
-                String content = transfer.taskToJson(task.get());
-                setJsonToResponseBody(exchange, content, 200);
+                Long id = parsePathToTaskId(path);
+                response = controller.getTasksWithId(id);
             } else {
-                exchange.sendResponseHeaders(200, 0);
+                response = new HttpResponse(200, "");
             }
         } else if (method.equals("POST")) {
             if (path.equals("/tasks")) {
+
                 String requestBody = new BufferedReader(
                         new InputStreamReader(exchange.getRequestBody()))
                         .lines()
                         .collect(Collectors.joining(""));
-                Task requestTask = transfer.jsonStringToTask(requestBody);
-
-                Long taskId = taskApplicationService.createTask(requestTask.getTitle());
-                sendUpdatedTaskResult(exchange, taskId, 201);
+                response = controller.postTask(requestBody);
             }
         } else if (method.equals("PUT")) {
             if (path.contains("/tasks")) {
                 Long taskId = parsePathToTaskId(path);
+
                 String requestBody = new BufferedReader(
                         new InputStreamReader(exchange.getRequestBody()))
                         .lines()
                         .collect(Collectors.joining(""));
-                Task requestTask = transfer.jsonStringToTask(requestBody);
-
-                Optional<Object> result = taskApplicationService.updateTaskTitle(taskId, requestTask.getTitle());
-
-                if (result.isEmpty()) {
-                    sendNotFoundError(exchange);
-                    return;
-                }
-                sendUpdatedTaskResult(exchange, taskId, 200);
+                response = controller.putTask(taskId, requestBody);
             }
         } else if (method.equals("DELETE")) {
             if (path.contains("/tasks")) {
                 Long taskId = parsePathToTaskId(path);
-                System.out.println(taskId);
-                Optional<Object> result = taskApplicationService.deleteTask(taskId);
-
-                if (result.isEmpty()) {
-                    sendNotFoundError(exchange);
-                    return;
-                }
-                exchange.sendResponseHeaders(204, 0);
+                response = controller.deleteTask(taskId);
             }
         } else {
-            sendNotFoundError(exchange);
+            response = new HttpResponse(404, "");
         }
+        writeHttpResponse(exchange, response);
     }
 
-    private void setJsonToResponseBody(HttpExchange exchange, String content, int statusCode) throws IOException {
-        exchange.getResponseHeaders().set("Content-Type", "application/json");
-        exchange.sendResponseHeaders(statusCode, content.getBytes().length);
-
+    private void writeHttpResponse(HttpExchange exchange, HttpResponse response) throws IOException {
+        exchange.sendResponseHeaders(response.statusCode, response.content.getBytes().length);
         OutputStream outputStream = exchange.getResponseBody();
-        outputStream.write(content.getBytes());
+        outputStream.write(response.content.getBytes());
         outputStream.flush();
-    }
-
-    private void sendUpdatedTaskResult(HttpExchange exchange, Long taskId, int statusCode) throws IOException {
-        Optional<Task> task = taskApplicationService.findTask(taskId);
-        if (task.isEmpty()) {
-            sendNotFoundError(exchange);
-            return;
-        }
-        String content = transfer.taskToJson(task.get());
-        setJsonToResponseBody(exchange, content, statusCode);
     }
 
     private Long parsePathToTaskId(String path){
@@ -115,8 +80,4 @@ public class WebHandler implements HttpHandler {
         return (long) Integer.parseInt(resourceId);
     }
 
-    private void sendNotFoundError(HttpExchange exchange) throws IOException {
-        String content = "{\"reason\": \"Not Found\"}";
-        setJsonToResponseBody(exchange, content, 404);
-    }
 }

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -1,6 +1,7 @@
 package com.codesoom.assignment.web;
 
 import com.codesoom.assignment.application.TaskApplicationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
@@ -8,6 +9,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -20,44 +23,62 @@ public class WebHandler implements HttpHandler {
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
-        Controller controller = new Controller(taskApplicationService);
         String path = exchange.getRequestURI().getPath();
         String method = exchange.getRequestMethod();
 
-        HttpResponse response = null;
         String requestBody = new BufferedReader(
                 new InputStreamReader(exchange.getRequestBody()))
                 .lines()
                 .collect(Collectors.joining(""));
-        HttpRequest request = new HttpRequest(path, requestBody);
+        HttpRequest request = new HttpRequest(method, path, requestBody);
+        List<Mapping> mappingList = prepareMapping();
+        Optional<HttpResponse> response = mappingList.stream()
+            .filter(
+                it -> it.pattern.isMatched(request)
+            ).findFirst()
+            .map(
+                it -> {
+                    try {
+                        return it.controller.process(request);
+                    } catch (Exception e) {
+                        return new HttpResponse(500, "Server error");
+                    }
+                }
+            );
 
-        if (path.contains("/tasks/")) {
-            switch (method) {
-                case "GET":
-                    response = controller.getTasksWithId(request);
-                    break;
-                case "PUT":
-                    response = controller.putTask(request);
-                    break;
-                case "DELETE":
-                    response = controller.deleteTask(request);
-                    break;
-            }
-        }
-        if (path.equals("/tasks")) {
-            if (method.equals("GET")) {
-                response = controller.getTasks(request);
-            } else if (method.equals("POST")) {
-                response = controller.postTask(request);
-            }
-        }
-        if (path.equals("/")) {
-            response = new HttpResponse(200, "Welcome to Las's service!");
-        }
-        if (response == null) {
-            response = new HttpResponse(404, "Not Found");
-        }
-        writeHttpResponse(exchange, response);
+        writeHttpResponse(exchange, response.orElse(new HttpResponse(404, "Not Found")));
+    }
+
+    List<Mapping> prepareMapping() {
+        Controller controller = new Controller(taskApplicationService);
+        List<Mapping> mappingList = new ArrayList<>();
+
+        mappingList.add(new Mapping(
+                new ExpectRequestPattern("GET", "/tasks/\\d"),
+                controller::getTasksWithId
+        ));
+        mappingList.add(new Mapping(
+                new ExpectRequestPattern("GET", "/tasks$"),
+                controller::getTasks
+        ));
+        mappingList.add(new Mapping(
+                new ExpectRequestPattern("POST", "/tasks$"),
+                controller::postTask
+        ));
+        mappingList.add(new Mapping(
+                new ExpectRequestPattern("PUT", "/tasks/\\d"),
+                controller::putTask
+        ));
+        mappingList.add(new Mapping(
+                new ExpectRequestPattern("DELETE", "/tasks/\\d"),
+                controller::deleteTask
+        ));
+        mappingList.add(new Mapping(
+                new ExpectRequestPattern("GET", "/"),
+                (request -> new HttpResponse(200, "Welcome to Las's service!"))
+        ));
+
+        return mappingList;
     }
 
     private void writeHttpResponse(HttpExchange exchange, HttpResponse response) throws IOException {

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -1,26 +1,53 @@
 package com.codesoom.assignment.web;
 
+import com.codesoom.assignment.application.TaskApplicationService;
+import com.codesoom.assignment.application.TaskJsonTransfer;
+import com.codesoom.assignment.domain.NotFoundTask;
+import com.codesoom.assignment.domain.Task;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.util.stream.Collectors;
 
 public class WebHandler implements HttpHandler {
+    TaskApplicationService taskApplicationService;
+    TaskJsonTransfer transfer;
+
+    public WebHandler(TaskApplicationService taskApplicationService) {
+        this.taskApplicationService = taskApplicationService;
+        this.transfer = new TaskJsonTransfer();
+    }
+
     @Override
     public void handle(HttpExchange exchange) throws IOException {
         if (exchange.getRequestURI().getPath().equals("/tasks")) {
-            String content = "[]";
+            String content = transfer.taskListToJson(taskApplicationService.getAllTasks());
             setJsonToResponseBody(exchange, content, 200);
-        }
-        else if (exchange.getRequestURI().getPath().equals("/task")){
-            String content = "{\"id\":1,\"title\":\"Play Game\"}";
-            setJsonToResponseBody(exchange, content, 201);
-        }
-        else {
+        } else if (exchange.getRequestURI().getPath().equals("/task")) {
+            String requestBody = new BufferedReader(
+                    new InputStreamReader(exchange.getRequestBody()))
+                    .lines()
+                    .collect(Collectors.joining(""));
+            Task requestTask = transfer.jsonStringToTask(requestBody);
+
+            try {
+                Long taskId = taskApplicationService.createTask(requestTask.getTitle());
+                Task createdTask = taskApplicationService.findTask(taskId);
+
+                String content = transfer.taskToJson(createdTask);
+                setJsonToResponseBody(exchange, content, 201);
+            } catch (NotFoundTask notFoundTask) {
+                notFoundTask.printStackTrace();
+            }
+        } else {
             exchange.sendResponseHeaders(200, 0);
         }
     }
+
     private void setJsonToResponseBody(HttpExchange exchange, String content, int statusCode) throws IOException {
         exchange.getResponseHeaders().set("Content-Type", "application/json");
         exchange.sendResponseHeaders(statusCode, content.getBytes().length);

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -71,6 +71,10 @@ public class WebHandler implements HttpHandler {
                 new ExpectRequestPattern("GET", "/"),
                 (request -> Optional.of(new HttpResponse(200, "Welcome to Las's service!")))
         ));
+        mappingList.add(new Mapping(
+                new ExpectRequestPattern("HEAD", "/"),
+                (request -> Optional.of(new HttpResponse(200, "Welcome to Las's service!")))
+        ));
 
         return mappingList;
     }

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -8,6 +8,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class WebHandler implements HttpHandler {
@@ -28,26 +29,26 @@ public class WebHandler implements HttpHandler {
                 new InputStreamReader(exchange.getRequestBody()))
                 .lines()
                 .collect(Collectors.joining(""));
+        HttpRequest request = new HttpRequest(path, requestBody);
 
         if (path.contains("/tasks/")) {
-            Long id = parsePathToTaskId(path);
             switch (method) {
                 case "GET":
-                    response = controller.getTasksWithId(id);
+                    response = controller.getTasksWithId(request);
                     break;
                 case "PUT":
-                    response = controller.putTask(id, requestBody);
+                    response = controller.putTask(request);
                     break;
                 case "DELETE":
-                    response = controller.deleteTask(id);
+                    response = controller.deleteTask(request);
                     break;
             }
         }
         if (path.equals("/tasks")) {
             if (method.equals("GET")) {
-                response = controller.getTasks();
+                response = controller.getTasks(request);
             } else if (method.equals("POST")) {
-                response = controller.postTask(requestBody);
+                response = controller.postTask(request);
             }
         }
         if (path.equals("/")) {
@@ -65,10 +66,5 @@ public class WebHandler implements HttpHandler {
         outputStream.write(response.content.getBytes());
         outputStream.flush();
         outputStream.close();
-    }
-
-    private Long parsePathToTaskId(String path) {
-        String resourceId = path.split("/")[2];
-        return (long) Integer.parseInt(resourceId);
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebHandler.java
@@ -74,6 +74,8 @@ public class WebHandler implements HttpHandler {
                 }
                 sendUpdatedTaskResult(exchange, taskId, 200);
             }
+        } else {
+            sendNotFoundError(exchange);
         }
     }
 

--- a/app/src/main/java/com/codesoom/assignment/web/WebServer.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebServer.java
@@ -11,7 +11,7 @@ public class WebServer {
     public WebServer(int port) throws IOException {
         InetSocketAddress address = new InetSocketAddress("localhost", port);
         httpServer = HttpServer.create(address, 0);
-        httpServer.createContext("/");
+        httpServer.createContext("/", new WebHandler());
     }
 
     public void start() {

--- a/app/src/main/java/com/codesoom/assignment/web/WebServer.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebServer.java
@@ -1,5 +1,6 @@
 package com.codesoom.assignment.web;
 
+import com.codesoom.assignment.application.TaskApplicationService;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 
@@ -8,10 +9,14 @@ import java.net.InetSocketAddress;
 
 public class WebServer {
     HttpServer httpServer;
+    TaskApplicationService taskApplicationService;
+
     public WebServer(int port) throws IOException {
+        taskApplicationService = new TaskApplicationService();
+
         InetSocketAddress address = new InetSocketAddress("localhost", port);
         httpServer = HttpServer.create(address, 0);
-        httpServer.createContext("/", new WebHandler());
+        httpServer.createContext("/", new WebHandler(taskApplicationService));
     }
 
     public void start() {

--- a/app/src/main/java/com/codesoom/assignment/web/WebServer.java
+++ b/app/src/main/java/com/codesoom/assignment/web/WebServer.java
@@ -1,0 +1,24 @@
+package com.codesoom.assignment.web;
+
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+public class WebServer {
+    HttpServer httpServer;
+    public WebServer(int port) throws IOException {
+        InetSocketAddress address = new InetSocketAddress("localhost", port);
+        httpServer = HttpServer.create(address, 0);
+        httpServer.createContext("/");
+    }
+
+    public void start() {
+        httpServer.start();
+    }
+
+    public void close() {
+        httpServer.stop(0);
+    }
+}

--- a/app/src/test/java/com/codesoom/assignment/application/TaskApplicationServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskApplicationServiceTest.java
@@ -80,9 +80,7 @@ class TaskApplicationServiceTest {
         Long taskId = applicationService.createTask(title);
         assertNotNull(taskId);
 
-        assertDoesNotThrow(() -> {
-            applicationService.deleteTask(taskId);
-        });
+        assertDoesNotThrow(() -> applicationService.deleteTask(taskId));
         assertThrows(NotFoundTask.class, () -> applicationService.findTask(taskId));
     }
 

--- a/app/src/test/java/com/codesoom/assignment/application/TaskApplicationServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskApplicationServiceTest.java
@@ -89,4 +89,17 @@ class TaskApplicationServiceTest {
         Long uncreatedId = -1L;
         assertThrows(NotFoundTask.class, () -> applicationService.deleteTask(uncreatedId));
     }
+    
+    @Test
+    void createTaskAfterDeleteTask() {
+        String title = "Listen Music";
+        Long taskId = applicationService.createTask(title);
+        assertNotNull(taskId);
+
+        assertDoesNotThrow(() -> {
+            applicationService.deleteTask(taskId);
+            Long newTaskId = applicationService.createTask(title);
+            assertNotEquals(taskId, newTaskId);
+        });
+    }
 }

--- a/app/src/test/java/com/codesoom/assignment/application/TaskApplicationServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskApplicationServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -46,17 +47,15 @@ class TaskApplicationServiceTest {
         String title = "Listen Music";
         Long taskId = applicationService.createTask(title);
         assertNotNull(taskId);
-        assertDoesNotThrow(() -> {
-            Task task = applicationService.findTask(taskId);
-            assertNotNull(taskId);
-            assertEquals(taskId, task.getId());
-        });
+        Optional<Task> task = applicationService.findTask(taskId);
+        assertNotNull(taskId);
+        assertEquals(taskId, task.orElseThrow().getId());
     }
 
     @Test
     void getUncreatedTask() {
         Long uncreatedId = -1L;
-        assertThrows(NotFoundTask.class, () -> applicationService.findTask(uncreatedId));
+        assertThrows(NotFoundTask.class, () -> applicationService.findTask(uncreatedId).orElseThrow(NotFoundTask::new));
     }
 
     @Test
@@ -66,11 +65,11 @@ class TaskApplicationServiceTest {
         Long taskId = applicationService.createTask(title);
         assertNotNull(taskId);
         assertDoesNotThrow(() -> {
-            applicationService.updateTaskTitle(taskId, newTitle);
+            applicationService.updateTaskTitle(taskId, newTitle).orElseThrow();
 
-            Task updatedTask = applicationService.findTask(taskId);
-            assertEquals(taskId, updatedTask.getId());
-            assertEquals(newTitle, updatedTask.getTitle());
+            Optional<Task> updatedTask = applicationService.findTask(taskId);
+            assertEquals(taskId, updatedTask.orElseThrow().getId());
+            assertEquals(newTitle, updatedTask.orElseThrow().getTitle());
         });
     }
 
@@ -81,13 +80,13 @@ class TaskApplicationServiceTest {
         assertNotNull(taskId);
 
         assertDoesNotThrow(() -> applicationService.deleteTask(taskId));
-        assertThrows(NotFoundTask.class, () -> applicationService.findTask(taskId));
+        assertThrows(NotFoundTask.class, () -> applicationService.findTask(taskId).orElseThrow(NotFoundTask::new));
     }
 
     @Test
     void deleteWrongTask() {
         Long uncreatedId = -1L;
-        assertThrows(NotFoundTask.class, () -> applicationService.deleteTask(uncreatedId));
+        assertThrows(NotFoundTask.class, () -> applicationService.deleteTask(uncreatedId).orElseThrow(NotFoundTask::new));
     }
     
     @Test
@@ -97,7 +96,7 @@ class TaskApplicationServiceTest {
         assertNotNull(taskId);
 
         assertDoesNotThrow(() -> {
-            applicationService.deleteTask(taskId);
+            applicationService.deleteTask(taskId).orElseThrow();
             Long newTaskId = applicationService.createTask(title);
             assertNotEquals(taskId, newTaskId);
         });

--- a/app/src/test/java/com/codesoom/assignment/application/TaskApplicationServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskApplicationServiceTest.java
@@ -87,7 +87,7 @@ class TaskApplicationServiceTest {
     }
 
     @Test
-    void deleteWorngTask() {
+    void deleteWrongTask() {
         Long uncreatedId = -1L;
         assertThrows(NotFoundTask.class, () -> applicationService.deleteTask(uncreatedId));
     }

--- a/app/src/test/java/com/codesoom/assignment/application/TaskApplicationServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskApplicationServiceTest.java
@@ -73,4 +73,17 @@ class TaskApplicationServiceTest {
             assertEquals(newTitle, updatedTask.getTitle());
         });
     }
+
+    @Test
+    void deleteTask() {
+        String title = "Listen Music";
+        Long taskId = applicationService.createTask(title);
+        assertNotNull(taskId);
+
+        assertDoesNotThrow(() -> {
+            applicationService.deleteTask(taskId);
+            assertNotNull(taskId);
+        });
+        assertThrows(NotFoundTask.class, ()-> applicationService.findTask(taskId));
+    }
 }

--- a/app/src/test/java/com/codesoom/assignment/application/TaskApplicationServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskApplicationServiceTest.java
@@ -1,0 +1,76 @@
+package com.codesoom.assignment.application;
+
+import com.codesoom.assignment.domain.NotFoundTask;
+import com.codesoom.assignment.domain.Task;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TaskApplicationServiceTest {
+    TaskApplicationService applicationService;
+
+    @BeforeEach
+    void initializeApplicationService() {
+        applicationService = new TaskApplicationService();
+    }
+
+    @Test
+    void getAllEmptyTasks() {
+        List<Task> allTasks = applicationService.getAllTasks();
+        assertNotNull(allTasks);
+        assertEquals(0, allTasks.size());
+    }
+
+    @Test
+    void getAllTasks() {
+        String title = "Listen Music";
+        applicationService.createTask(title);
+
+        List<Task> allTasks = applicationService.getAllTasks();
+        assertNotNull(allTasks);
+        assertEquals(1, allTasks.size());
+    }
+
+    @Test
+    void createTask() {
+        String title = "Listen Music";
+        Long taskId = applicationService.createTask(title);
+        assertNotNull(taskId);
+    }
+
+    @Test
+    void getSpecificTask() {
+        String title = "Listen Music";
+        Long taskId = applicationService.createTask(title);
+        assertNotNull(taskId);
+        assertDoesNotThrow(() -> {
+            Task task = applicationService.findTask(taskId);
+            assertNotNull(taskId);
+            assertEquals(taskId, task.getId());
+        });
+    }
+
+    @Test
+    void getUncreatedTask() {
+        Long uncreatedId = -1L;
+        assertThrows(NotFoundTask.class, () -> applicationService.findTask(uncreatedId));
+    }
+
+    @Test
+    void updateTask() {
+        String title = "Listen Music";
+        String newTitle = "Play Game!!";
+        Long taskId = applicationService.createTask(title);
+        assertNotNull(taskId);
+        assertDoesNotThrow(() -> {
+            applicationService.updateTaskTitle(taskId, newTitle);
+
+            Task updatedTask = applicationService.findTask(taskId);
+            assertEquals(taskId, updatedTask.getId());
+            assertEquals(newTitle, updatedTask.getTitle());
+        });
+    }
+}

--- a/app/src/test/java/com/codesoom/assignment/application/TaskApplicationServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskApplicationServiceTest.java
@@ -82,8 +82,13 @@ class TaskApplicationServiceTest {
 
         assertDoesNotThrow(() -> {
             applicationService.deleteTask(taskId);
-            assertNotNull(taskId);
         });
-        assertThrows(NotFoundTask.class, ()-> applicationService.findTask(taskId));
+        assertThrows(NotFoundTask.class, () -> applicationService.findTask(taskId));
+    }
+
+    @Test
+    void deleteWorngTask() {
+        Long uncreatedId = -1L;
+        assertThrows(NotFoundTask.class, () -> applicationService.deleteTask(uncreatedId));
     }
 }

--- a/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
@@ -1,0 +1,20 @@
+package com.codesoom.assignment.application;
+
+import com.codesoom.assignment.domain.Task;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class TaskJsonTransferTest {
+    TaskJsonTransfer transfer = new TaskJsonTransfer();
+
+    @Test
+    void transferJsonToTask(){
+        String jsonString = "{\"title\": \"Play Game\"}";
+        Task task = transfer.jsonStringToTask(jsonString);
+
+        assertNotNull(task);
+        assertEquals("Play Game", task.getTitle());
+    }
+}

--- a/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
@@ -18,4 +18,16 @@ public class TaskJsonTransferTest {
             assertEquals("Play Game", task.getTitle());
         });
     }
+
+    @Test
+    void transferTaskToJson(){
+        String expectJsonString = "{\"id\": 1, \"title\": \"Play Game\"}";
+        Task task = new Task(1L, "Play Game");
+
+        assertDoesNotThrow(()-> {
+            String json = transfer.taskToJson(task);
+
+            assertEquals(expectJsonString, json);
+        });
+    }
 }

--- a/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
@@ -9,9 +9,9 @@ public class TaskJsonTransferTest {
     TaskJsonTransfer transfer = new TaskJsonTransfer();
 
     @Test
-    void transferJsonToTask(){
+    void transferJsonToTask() {
         String jsonString = "{\"title\": \"Play Game\"}";
-        assertDoesNotThrow(()-> {
+        assertDoesNotThrow(() -> {
             Task task = transfer.jsonStringToTask(jsonString);
 
             assertNotNull(task);
@@ -20,11 +20,11 @@ public class TaskJsonTransferTest {
     }
 
     @Test
-    void transferTaskToJson(){
+    void transferTaskToJson() {
         String expectJsonString = "{\"id\":1,\"title\":\"Play Game\"}";
         Task task = new Task(1L, "Play Game");
 
-        assertDoesNotThrow(()-> {
+        assertDoesNotThrow(() -> {
             String json = transfer.taskToJson(task);
 
             assertEquals(expectJsonString, json);

--- a/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
@@ -3,6 +3,9 @@ package com.codesoom.assignment.application;
 import com.codesoom.assignment.domain.Task;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TaskJsonTransferTest {
@@ -34,10 +37,13 @@ public class TaskJsonTransferTest {
     @Test
     void transferTaskListToJsonArray() {
         String expectJsonString = "[{\"id\":1,\"title\":\"Play Game\"}]";
+
+        List<Task> taskList = new ArrayList<>();
         Task task = new Task(1L, "Play Game");
+        taskList.add(task);
 
         assertDoesNotThrow(() -> {
-            String json = transfer.taskListToJson(task);
+            String json = transfer.taskListToJson(taskList);
 
             assertEquals(expectJsonString, json);
         });

--- a/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
@@ -3,8 +3,7 @@ package com.codesoom.assignment.application;
 import com.codesoom.assignment.domain.Task;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TaskJsonTransferTest {
     TaskJsonTransfer transfer = new TaskJsonTransfer();
@@ -12,9 +11,11 @@ public class TaskJsonTransferTest {
     @Test
     void transferJsonToTask(){
         String jsonString = "{\"title\": \"Play Game\"}";
-        Task task = transfer.jsonStringToTask(jsonString);
+        assertDoesNotThrow(()-> {
+            Task task = transfer.jsonStringToTask(jsonString);
 
-        assertNotNull(task);
-        assertEquals("Play Game", task.getTitle());
+            assertNotNull(task);
+            assertEquals("Play Game", task.getTitle());
+        });
     }
 }

--- a/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
@@ -15,7 +15,7 @@ public class TaskJsonTransferTest {
     void transferJsonToTask() {
         String jsonString = "{\"title\": \"Play Game\"}";
         assertDoesNotThrow(() -> {
-            Task task = transfer.jsonStringToTask(jsonString);
+            Task task = transfer.jsonStringToTask(jsonString).orElseThrow();
 
             assertNotNull(task);
             assertEquals("Play Game", task.getTitle());
@@ -28,7 +28,7 @@ public class TaskJsonTransferTest {
         Task task = new Task(1L, "Play Game");
 
         assertDoesNotThrow(() -> {
-            String json = transfer.taskToJson(task);
+            String json = transfer.taskToJson(task).orElseThrow();
 
             assertEquals(expectJsonString, json);
         });
@@ -43,7 +43,7 @@ public class TaskJsonTransferTest {
         taskList.add(task);
 
         assertDoesNotThrow(() -> {
-            String json = transfer.taskListToJson(taskList);
+            String json = transfer.taskListToJson(taskList).orElseThrow();
 
             assertEquals(expectJsonString, json);
         });

--- a/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
@@ -30,4 +30,17 @@ public class TaskJsonTransferTest {
             assertEquals(expectJsonString, json);
         });
     }
+
+    @Test
+    void transferTaskListToJsonArray() {
+        String expectJsonString = "[{\"id\":1,\"title\":\"Play Game\"}]";
+        Task task = new Task(1L, "Play Game");
+
+        assertDoesNotThrow(() -> {
+            String json = transfer.taskListToJson(task);
+
+            assertEquals(expectJsonString, json);
+        });
+
+    }
 }

--- a/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskJsonTransferTest.java
@@ -21,7 +21,7 @@ public class TaskJsonTransferTest {
 
     @Test
     void transferTaskToJson(){
-        String expectJsonString = "{\"id\": 1, \"title\": \"Play Game\"}";
+        String expectJsonString = "{\"id\":1,\"title\":\"Play Game\"}";
         Task task = new Task(1L, "Play Game");
 
         assertDoesNotThrow(()-> {

--- a/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
@@ -5,6 +5,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -16,15 +17,20 @@ public class WebServerTest {
 
     @BeforeEach
     void openServer() {
-        server = new WebServer(8000);
+        assertDoesNotThrow(() -> {
+            server = new WebServer(8000);
+        });
+        server.start();
     }
+
     @AfterEach
     void closeServer() {
         server.close();
     }
+
     @Test
-    void getRoot(){
-        HttpUriRequest request = new HttpGet( "http://localhost:8000");
+    void getRoot() {
+        HttpUriRequest request = new HttpGet("http://localhost:8000");
         assertDoesNotThrow(() -> {
             HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
 

--- a/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
@@ -1,0 +1,32 @@
+package com.codesoom.assignment.web;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class WebServerTest {
+    @BeforeEach
+    void openServer() {
+        // Open server fot testing.
+    }
+    @AfterEach
+    void closeServer() {
+        // Close server fot testing.
+    }
+    @Test
+    void getRoot(){
+        HttpUriRequest request = new HttpGet( "http://localhost:8000");
+        assertDoesNotThrow(() -> {
+            HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
+
+            assertEquals(200, httpResponse.getStatusLine().getStatusCode());
+        });
+    }
+}

--- a/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
@@ -3,6 +3,7 @@ package com.codesoom.assignment.web;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -109,6 +110,19 @@ public class WebServerTest {
         HttpUriRequest request = new HttpGet("http://localhost:8000/task/1");
         assertDoesNotThrow(() -> {
             HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
+            assertEquals(404, httpResponse.getStatusLine().getStatusCode());
+        });
+    }
+
+    @Test
+    void putUnCreatedTask() {
+        HttpPut put = new HttpPut("http://localhost:8000/task/1");
+        String requestBody = "{\"title\": \"Play Game\"}";
+        assertDoesNotThrow(() -> {
+            StringEntity requestEntity = new StringEntity(requestBody);
+            put.setEntity(requestEntity);
+
+            HttpResponse httpResponse = HttpClientBuilder.create().build().execute(put);
             assertEquals(404, httpResponse.getStatusLine().getStatusCode());
         });
     }

--- a/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
@@ -12,13 +12,15 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class WebServerTest {
+    WebServer server;
+
     @BeforeEach
     void openServer() {
-        // Open server fot testing.
+        server = new WebServer(8000);
     }
     @AfterEach
     void closeServer() {
-        // Close server fot testing.
+        server.close();
     }
     @Test
     void getRoot(){

--- a/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
@@ -78,4 +78,28 @@ public class WebServerTest {
             assertEquals("{\"id\":1,\"title\":\"Play Game\"}", responseBody);
         });
     }
+
+    @Test
+    void getSpecificTask() {
+        // create task for get.
+        HttpPost post = new HttpPost("http://localhost:8000/task");
+        String requestBody = "{\"title\": \"Play Game\"}";
+        assertDoesNotThrow(() -> {
+            StringEntity requestEntity = new StringEntity(requestBody);
+            post.setEntity(requestEntity);
+        });
+
+        HttpUriRequest request = new HttpGet("http://localhost:8000/task/1");
+        assertDoesNotThrow(() -> {
+            HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
+            String responseBody = new BufferedReader(
+                new InputStreamReader(httpResponse.getEntity().getContent()))
+                .lines()
+                .collect(Collectors.joining(""));
+
+            assertEquals(200, httpResponse.getStatusLine().getStatusCode());
+            assertNotNull(httpResponse.getEntity().getContentType());
+            assertEquals("{\"id\":1,\"title\":\"Play Game\"}", responseBody);
+        });
+    }
 }

--- a/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
@@ -87,6 +87,7 @@ public class WebServerTest {
         assertDoesNotThrow(() -> {
             StringEntity requestEntity = new StringEntity(requestBody);
             post.setEntity(requestEntity);
+            HttpClientBuilder.create().build().execute(post);
         });
 
         HttpUriRequest request = new HttpGet("http://localhost:8000/task/1");

--- a/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
@@ -9,8 +9,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class WebServerTest {
     WebServer server;
@@ -35,6 +34,16 @@ public class WebServerTest {
             HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
 
             assertEquals(200, httpResponse.getStatusLine().getStatusCode());
+        });
+    }
+    @Test
+    void getAllEmptyTask() {
+        HttpUriRequest request = new HttpGet("http://localhost:8000/tasks");
+        assertDoesNotThrow(() -> {
+            HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
+
+            assertEquals(200, httpResponse.getStatusLine().getStatusCode());
+            assertNotNull(httpResponse.getFirstHeader("Content-Type"));
         });
     }
 }

--- a/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
@@ -83,7 +83,7 @@ public class WebServerTest {
     @Test
     void getSpecificTask() {
         // create task for get.
-        HttpPost post = new HttpPost("http://localhost:8000/task");
+        HttpPost post = new HttpPost("http://localhost:8000/tasks");
         String requestBody = "{\"title\": \"Play Game\"}";
         assertDoesNotThrow(() -> {
             StringEntity requestEntity = new StringEntity(requestBody);
@@ -91,7 +91,7 @@ public class WebServerTest {
             HttpClientBuilder.create().build().execute(post);
         });
 
-        HttpUriRequest request = new HttpGet("http://localhost:8000/task/1");
+        HttpUriRequest request = new HttpGet("http://localhost:8000/tasks/0");
         assertDoesNotThrow(() -> {
             HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
             String responseBody = new BufferedReader(
@@ -107,7 +107,7 @@ public class WebServerTest {
 
     @Test
     void getUnCreatedTask() {
-        HttpUriRequest request = new HttpGet("http://localhost:8000/task/1");
+        HttpUriRequest request = new HttpGet("http://localhost:8000/tasks/1");
         assertDoesNotThrow(() -> {
             HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
             assertEquals(404, httpResponse.getStatusLine().getStatusCode());
@@ -116,7 +116,7 @@ public class WebServerTest {
 
     @Test
     void putUnCreatedTask() {
-        HttpPut put = new HttpPut("http://localhost:8000/task/1");
+        HttpPut put = new HttpPut("http://localhost:8000/tasks/1");
         String requestBody = "{\"title\": \"Play Game\"}";
         assertDoesNotThrow(() -> {
             StringEntity requestEntity = new StringEntity(requestBody);

--- a/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
@@ -5,9 +5,12 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -36,14 +39,20 @@ public class WebServerTest {
             assertEquals(200, httpResponse.getStatusLine().getStatusCode());
         });
     }
+
     @Test
     void getAllEmptyTask() {
         HttpUriRequest request = new HttpGet("http://localhost:8000/tasks");
         assertDoesNotThrow(() -> {
             HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
+            String responseBody = new BufferedReader(
+                new InputStreamReader(httpResponse.getEntity().getContent()))
+                .lines()
+                .collect(Collectors.joining(""));
 
             assertEquals(200, httpResponse.getStatusLine().getStatusCode());
             assertNotNull(httpResponse.getEntity().getContentType());
+            assertEquals("[]", responseBody);
         });
     }
 }

--- a/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
@@ -43,7 +43,7 @@ public class WebServerTest {
             HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
 
             assertEquals(200, httpResponse.getStatusLine().getStatusCode());
-            assertNotNull(httpResponse.getFirstHeader("Content-Type"));
+            assertNotNull(httpResponse.getEntity().getContentType());
         });
     }
 }

--- a/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
@@ -2,14 +2,15 @@ package com.codesoom.assignment.web;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -46,13 +47,35 @@ public class WebServerTest {
         assertDoesNotThrow(() -> {
             HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
             String responseBody = new BufferedReader(
-                new InputStreamReader(httpResponse.getEntity().getContent()))
-                .lines()
-                .collect(Collectors.joining(""));
+                    new InputStreamReader(httpResponse.getEntity().getContent()))
+                    .lines()
+                    .collect(Collectors.joining(""));
 
             assertEquals(200, httpResponse.getStatusLine().getStatusCode());
             assertNotNull(httpResponse.getEntity().getContentType());
             assertEquals("[]", responseBody);
+        });
+    }
+
+    @Test
+    void createNewTask() {
+        HttpPost post = new HttpPost("http://localhost:8000/task");
+        String requestBody = "{\"title\": \"Play Game\"}";
+        assertDoesNotThrow(() -> {
+            StringEntity requestEntity = new StringEntity(requestBody);
+            post.setEntity(requestEntity);
+        });
+
+        assertDoesNotThrow(() -> {
+            HttpResponse httpResponse = HttpClientBuilder.create().build().execute(post);
+            String responseBody = new BufferedReader(
+                new InputStreamReader(httpResponse.getEntity().getContent()))
+                .lines()
+                .collect(Collectors.joining(""));
+
+            assertEquals(201, httpResponse.getStatusLine().getStatusCode());
+            assertNotNull(httpResponse.getEntity().getContentType());
+            assertEquals("{\"id\":1,\"title\":\"Play Game\"}", responseBody);
         });
     }
 }

--- a/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
@@ -53,14 +53,13 @@ public class WebServerTest {
                     .collect(Collectors.joining(""));
 
             assertEquals(200, httpResponse.getStatusLine().getStatusCode());
-            assertNotNull(httpResponse.getEntity().getContentType());
             assertEquals("[]", responseBody);
         });
     }
 
     @Test
     void createNewTask() {
-        HttpPost post = new HttpPost("http://localhost:8000/task");
+        HttpPost post = new HttpPost("http://localhost:8000/tasks");
         String requestBody = "{\"title\": \"Play Game\"}";
         assertDoesNotThrow(() -> {
             StringEntity requestEntity = new StringEntity(requestBody);
@@ -75,7 +74,6 @@ public class WebServerTest {
                 .collect(Collectors.joining(""));
 
             assertEquals(201, httpResponse.getStatusLine().getStatusCode());
-            assertNotNull(httpResponse.getEntity().getContentType());
             assertEquals("{\"id\":1,\"title\":\"Play Game\"}", responseBody);
         });
     }
@@ -91,7 +89,7 @@ public class WebServerTest {
             HttpClientBuilder.create().build().execute(post);
         });
 
-        HttpUriRequest request = new HttpGet("http://localhost:8000/tasks/0");
+        HttpUriRequest request = new HttpGet("http://localhost:8000/tasks/1");
         assertDoesNotThrow(() -> {
             HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
             String responseBody = new BufferedReader(
@@ -100,7 +98,6 @@ public class WebServerTest {
                 .collect(Collectors.joining(""));
 
             assertEquals(200, httpResponse.getStatusLine().getStatusCode());
-            assertNotNull(httpResponse.getEntity().getContentType());
             assertEquals("{\"id\":1,\"title\":\"Play Game\"}", responseBody);
         });
     }

--- a/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/web/WebServerTest.java
@@ -103,4 +103,13 @@ public class WebServerTest {
             assertEquals("{\"id\":1,\"title\":\"Play Game\"}", responseBody);
         });
     }
+
+    @Test
+    void getUnCreatedTask() {
+        HttpUriRequest request = new HttpGet("http://localhost:8000/task/1");
+        assertDoesNotThrow(() -> {
+            HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
+            assertEquals(404, httpResponse.getStatusLine().getStatusCode());
+        });
+    }
 }


### PR DESCRIPTION
Task를 관리하는 application service와 그 테스트를 작성하였습니다.

아직 웹에 대한 것들을 고려하진 않았으며, 다음 PR에서 고려할 예정입니다. 또한 application service의 모든 method를 구현 / 테스트를 작성한 것은 아니기에 추가될 가능성이 있습니다.

이러한 것들을 고려하지 않은 이유는 추후에 생길 task에 관한 사용에 대한 복잡성을 고려하였기 때문입니다. 이러한 task를 관리하는 코드를 application service로 격리시키고, 이를 http server에서 사용할 예정입니다.